### PR TITLE
Add counter for number of executions (per worker / overall)

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -3,23 +3,30 @@ package pool
 import (
 	"runtime"
 	"sync"
+	"sync/atomic"
 )
 
 type WorkerPool struct {
 	wg   sync.WaitGroup
 	once sync.Once
-	jobs chan func()
+	jobs chan func(uint64)
+	n    uint64
 }
 
-func (p *WorkerPool) Do(f func()) {
+func (p *WorkerPool) Do(f func(n uint64)) {
 	p.once.Do(func() {
-		p.jobs = make(chan func(), runtime.NumCPU()*2)
+		p.jobs = make(chan func(uint64), runtime.NumCPU()*2)
 		for i := 0; i < runtime.NumCPU(); i++ {
 			p.wg.Add(1)
 			go func() {
 				defer p.wg.Done()
+				var n uint64
+				defer func() {
+					atomic.AddUint64(&p.n, n)
+				}()
 				for job := range p.jobs {
-					job()
+					job(n)
+					n++
 				}
 			}()
 		}
@@ -27,9 +34,10 @@ func (p *WorkerPool) Do(f func()) {
 	p.jobs <- f
 }
 
-func (p *WorkerPool) Done() {
+func (p *WorkerPool) Done() uint64 {
 	if p.jobs != nil {
 		close(p.jobs)
 		p.wg.Wait()
 	}
+	return p.n
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,16 @@
+package pool
+
+import "testing"
+
+func TestBasic(t *testing.T) {
+	count := 1000
+	p := new(WorkerPool)
+	for i := 0; i < count; i++ {
+		p.Do(func(n uint64) {
+			// NOOP
+		})
+	}
+	if n := p.Done(); n != uint64(count) {
+		t.Fatalf("Extected %v, got %v", count, n)
+	}
+}


### PR DESCRIPTION
Sometimes it is needed to check the number of actual execution being made by a worker as well as the overall execution count.
